### PR TITLE
Fix PyPI publishing workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -86,8 +86,17 @@ jobs:
       shell: bash
       run: |
         source .venv/bin/activate
+        # Install build dependencies
         python -m pip install build hatchling
+        # Install shotgun-api3 from GitHub
+        python -m pip install git+https://github.com/shotgunsoftware/python-api.git@v3.8.2
+        # Create a temporary pyproject.toml without direct references
+        cp pyproject.toml pyproject.toml.bak
+        sed -i 's|"shotgun-api3@git+https://github.com/shotgunsoftware/python-api.git@v3.8.2",|"shotgun-api3",|g' pyproject.toml
+        # Build the package
         python -m build --wheel --no-isolation
+        # Restore original pyproject.toml
+        mv pyproject.toml.bak pyproject.toml
 
     # Note that we don't need credentials.
     # We rely on https://docs.pypi.org/trusted-publishers/.

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -68,18 +68,24 @@ jobs:
         else
           source .venv/bin/activate
         fi
-        uv pip install -r requirements-dev.txt
+        uv pip install -e ".[dev]"
 
     - name: Lint
+      shell: bash
       run: |
-        uvx nox -s lint
+        source .venv/bin/activate
+        python -m nox -s lint
 
     - name: Test
+      shell: bash
       run: |
-        uvx nox -s tests
+        source .venv/bin/activate
+        python -m nox -s tests
 
     - name: Build package
+      shell: bash
       run: |
+        source .venv/bin/activate
         python -m pip install build hatchling
         python -m build --wheel --no-isolation
 


### PR DESCRIPTION
This PR fixes the PyPI publishing workflow by:

1. Ensuring virtual environment is properly created and activated in all workflow steps
2. Using `python -m nox` instead of `uvx nox` to ensure commands run in the correct environment
3. Handling direct Git dependencies for PyPI publishing by temporarily modifying pyproject.toml

These changes should resolve the issues with the PyPI publishing workflow.