### PR TITLE
Fix CI workflow using uvx for all commands

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -61,43 +61,32 @@ jobs:
       shell: bash
       run: |
         python -m pip install --upgrade pip
-        # Create virtual environment using Python's built-in venv module
-        python -m venv .venv
-        if [ "$RUNNER_OS" = "Windows" ]; then
-          source .venv/Scripts/activate
-        else
-          source .venv/bin/activate
-        fi
-        # Upgrade pip in the virtual environment
-        python -m pip install --upgrade pip
-        # Install the project in development mode
-        python -m pip install -e ".[dev]"
+        python -m pip install uv
+        # Install the project in development mode using uvx
+        uvx pip install -e ".[dev]"
 
     - name: Lint
       shell: bash
       run: |
-        source .venv/bin/activate
-        python -m nox -s lint
+        uvx nox -s lint
 
     - name: Test
       shell: bash
       run: |
-        source .venv/bin/activate
-        python -m nox -s tests
+        uvx nox -s tests
 
     - name: Build package
       shell: bash
       run: |
-        source .venv/bin/activate
         # Install build dependencies
-        python -m pip install build hatchling
+        uvx pip install build hatchling
         # Install shotgun-api3 from GitHub
-        python -m pip install git+https://github.com/shotgunsoftware/python-api.git@v3.8.2
+        uvx pip install git+https://github.com/shotgunsoftware/python-api.git@v3.8.2
         # Create a temporary pyproject.toml without direct references
         cp pyproject.toml pyproject.toml.bak
         sed -i 's|"shotgun-api3@git+https://github.com/shotgunsoftware/python-api.git@v3.8.2",|"shotgun-api3",|g' pyproject.toml
         # Build the package
-        python -m build --wheel --no-isolation
+        uvx python -m build --wheel --no-isolation
         # Restore original pyproject.toml
         mv pyproject.toml.bak pyproject.toml
 

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -61,14 +61,17 @@ jobs:
       shell: bash
       run: |
         python -m pip install --upgrade pip
-        python -m pip install uv
-        uv venv
+        # Create virtual environment using Python's built-in venv module
+        python -m venv .venv
         if [ "$RUNNER_OS" = "Windows" ]; then
           source .venv/Scripts/activate
         else
           source .venv/bin/activate
         fi
-        uv pip install -e ".[dev]"
+        # Upgrade pip in the virtual environment
+        python -m pip install --upgrade pip
+        # Install the project in development mode
+        python -m pip install -e ".[dev]"
 
     - name: Lint
       shell: bash


### PR DESCRIPTION
This PR fixes the CI workflow by using `uvx` for all commands to avoid pip module issues.

The issue was that the virtual environment didn't have pip properly installed, causing the 'No module named pip' error during the build step.

By using `uvx` for all commands, we avoid the need to activate a virtual environment and ensure that all commands run in a consistent environment with all required dependencies.