### PR TITLE
Fix Python version specification for uvx

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,23 @@ uv pip install shotgrid-mcp-server
 
 Once installed, you can start the server directly with:
 ```bash
+uvx --python 3.10 shotgrid-mcp-server
+```
+
+**Important**: The ShotGrid MCP server requires Python 3.10. When using `uvx`, you must specify the Python version with `--python 3.10` to ensure compatibility, as `uvx` may default to using the latest Python version (e.g., 3.13) which is not compatible with this package.
+
+Alternatively, you can set the Python version using an environment variable:
+```bash
+# Windows
+set UV_PYTHON=3.10
+uvx shotgrid-mcp-server
+
+# Linux/macOS
+export UV_PYTHON=3.10
 uvx shotgrid-mcp-server
 ```
 
-This will start the ShotGrid MCP server with default settings. Make sure you have set the required environment variables (SHOTGRID_URL, SHOTGRID_SCRIPT_NAME, SHOTGRID_SCRIPT_KEY) before starting the server.
+Make sure you have set the required environment variables (SHOTGRID_URL, SHOTGRID_SCRIPT_NAME, SHOTGRID_SCRIPT_KEY) before starting the server.
 
 ### Development Setup
 
@@ -221,6 +234,7 @@ To use the ShotGrid MCP server in your MCP client, add the appropriate configura
     "shotgrid-server": {
       "command": "uvx",
       "args": [
+        "--python", "3.10",
         "shotgrid-mcp-server"
       ],
       "env": {
@@ -255,6 +269,7 @@ To use the ShotGrid MCP server in your MCP client, add the appropriate configura
     "shotgrid-server": {
       "command": "uvx",
       "args": [
+        "--python", "3.10",
         "shotgrid-mcp-server"
       ],
       "env": {
@@ -276,6 +291,7 @@ To use the ShotGrid MCP server in your MCP client, add the appropriate configura
     "shotgrid-server": {
       "command": "uvx",
       "args": [
+        "--python", "3.10",
         "shotgrid-mcp-server"
       ],
       "env": {
@@ -297,6 +313,7 @@ To use the ShotGrid MCP server in your MCP client, add the appropriate configura
     "shotgrid-server": {
       "command": "uvx",
       "args": [
+        "--python", "3.10",
         "shotgrid-mcp-server"
       ],
       "env": {
@@ -338,7 +355,7 @@ To use the ShotGrid MCP server in your MCP client, add the appropriate configura
     "shotgrid-server": {
       "type": "stdio",
       "command": "uvx",
-      "args": ["shotgrid-mcp-server"],
+      "args": ["--python", "3.10", "shotgrid-mcp-server"],
       "env": {
         "SHOTGRID_SCRIPT_NAME": "${input:shotgrid-script-name}",
         "SHOTGRID_SCRIPT_KEY": "${input:shotgrid-script-key}",
@@ -358,7 +375,7 @@ To use the ShotGrid MCP server in your MCP client, add the appropriate configura
     "shotgrid-server": {
       "type": "stdio",
       "command": "uvx",
-      "args": ["shotgrid-mcp-server"],
+      "args": ["--python", "3.10", "shotgrid-mcp-server"],
       "env": {
         "SHOTGRID_SCRIPT_NAME": "XXX",
         "SHOTGRID_SCRIPT_KEY": "XX",

--- a/README_zh.md
+++ b/README_zh.md
@@ -43,10 +43,23 @@ uv pip install shotgrid-mcp-server
 
 安装完成后，您可以直接使用以下命令启动服务器：
 ```bash
+uvx --python 3.10 shotgrid-mcp-server
+```
+
+**重要提示**：ShotGrid MCP服务器需要Python 3.10。使用`uvx`时，必须使用`--python 3.10`参数指定Python版本以确保兼容性，因为`uvx`可能默认使用最新的Python版本（例如3.13），而这与本包不兼容。
+
+您也可以通过环境变量设置Python版本：
+```bash
+# Windows
+set UV_PYTHON=3.10
+uvx shotgrid-mcp-server
+
+# Linux/macOS
+export UV_PYTHON=3.10
 uvx shotgrid-mcp-server
 ```
 
-这将使用默认设置启动ShotGrid MCP服务器。请确保在启动服务器之前已设置必要的环境变量（SHOTGRID_URL，SHOTGRID_SCRIPT_NAME，SHOTGRID_SCRIPT_KEY）。
+请确保在启动服务器之前已设置必要的环境变量（SHOTGRID_URL，SHOTGRID_SCRIPT_NAME，SHOTGRID_SCRIPT_KEY）。
 
 ### 开发环境设置
 
@@ -220,6 +233,7 @@ MIT许可证 - 查看[LICENSE](LICENSE)文件了解详情。
     "shotgrid-server": {
       "command": "uvx",
       "args": [
+        "--python", "3.10",
         "shotgrid-mcp-server"
       ],
       "env": {
@@ -254,6 +268,7 @@ MIT许可证 - 查看[LICENSE](LICENSE)文件了解详情。
     "shotgrid-server": {
       "command": "uvx",
       "args": [
+        "--python", "3.10",
         "shotgrid-mcp-server"
       ],
       "env": {
@@ -275,6 +290,7 @@ MIT许可证 - 查看[LICENSE](LICENSE)文件了解详情。
     "shotgrid-server": {
       "command": "uvx",
       "args": [
+        "--python", "3.10",
         "shotgrid-mcp-server"
       ],
       "env": {
@@ -296,6 +312,7 @@ MIT许可证 - 查看[LICENSE](LICENSE)文件了解详情。
     "shotgrid-server": {
       "command": "uvx",
       "args": [
+        "--python", "3.10",
         "shotgrid-mcp-server"
       ],
       "env": {
@@ -337,7 +354,7 @@ MIT许可证 - 查看[LICENSE](LICENSE)文件了解详情。
     "shotgrid-server": {
       "type": "stdio",
       "command": "uvx",
-      "args": ["shotgrid-mcp-server"],
+      "args": ["--python", "3.10", "shotgrid-mcp-server"],
       "env": {
         "SHOTGRID_SCRIPT_NAME": "${input:shotgrid-script-name}",
         "SHOTGRID_SCRIPT_KEY": "${input:shotgrid-script-key}",
@@ -357,7 +374,7 @@ MIT许可证 - 查看[LICENSE](LICENSE)文件了解详情。
     "shotgrid-server": {
       "type": "stdio",
       "command": "uvx",
-      "args": ["shotgrid-mcp-server"],
+      "args": ["--python", "3.10", "shotgrid-mcp-server"],
       "env": {
         "SHOTGRID_SCRIPT_NAME": "XXX",
         "SHOTGRID_SCRIPT_KEY": "XX",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,3 +181,8 @@ addopts = "-v --cov=shotgrid_mcp_server --cov-report=term-missing"
 dependencies = [
     "git+https://github.com/shotgunsoftware/python-api.git#egg=shotgun-api3"
 ]
+python = "3.10"
+
+[tool.uv]
+python = "3.10"
+python-preference = "only-managed"


### PR DESCRIPTION
## Description

This PR fixes an issue where uvx defaults to using the latest Python version (e.g., 3.13) which is not compatible with the shotgrid-mcp-server package that requires Python 3.10.

## Changes

- Added Python version configuration in pyproject.toml
- Updated documentation to specify the need to use `--python 3.10` with uvx
- Updated all MCP client configuration examples to include the Python version parameter
- Added alternative method using environment variable `UV_PYTHON=3.10`

## Testing

Tested with uvx to ensure it correctly uses Python 3.10 when specified.

Signed-off-by: loonghao <hal.long@outlook.com>