### PR TITLE
Standardize tool naming convention

### DIFF
--- a/docs/guides/tool-naming-convention.mdx
+++ b/docs/guides/tool-naming-convention.mdx
@@ -1,0 +1,176 @@
+---
+title: 'Tool Naming Convention'
+description: 'Guidelines for naming and creating new tools in ShotGrid MCP Server'
+---
+
+# Tool Naming Convention
+
+This document outlines the naming convention for tools in the ShotGrid MCP Server and provides guidelines for creating new tools.
+
+## MCP Tool Name Requirements
+
+According to the Model Context Protocol (MCP) specification, tool names must follow these requirements:
+
+- Tool names must match the regular expression pattern: `^[a-zA-Z0-9_-]{1,64}$`
+- This means tool names:
+  - Can only contain letters, numbers, underscores, and hyphens
+  - Cannot contain periods, spaces, or other special characters
+  - Must be between 1 and 64 characters in length
+
+## ShotGrid MCP Server Tool Naming Convention
+
+To maintain consistency and clarity, we follow these naming conventions for tools in the ShotGrid MCP Server:
+
+### Prefix-Based Naming
+
+All tools should use a prefix that indicates their category:
+
+| Prefix | Description | Example |
+|--------|-------------|---------|
+| `sg_` | Direct ShotGrid API wrappers | `sg_find`, `sg_create` |
+| `entity_` | Entity operations | `entity_create`, `entity_update` |
+| `note_` | Note-related operations | `note_create`, `note_read` |
+| `playlist_` | Playlist-related operations | `playlist_create`, `playlist_find` |
+| `thumbnail_` | Thumbnail-related operations | `thumbnail_get_url`, `thumbnail_download` |
+| `vendor_` | Vendor-related operations | `vendor_find_users`, `vendor_create_playlist` |
+| `search_` | Search-related operations | `search_entities`, `search_by_date` |
+| `batch_` | Batch operations | `batch_create`, `batch_download` |
+
+### Naming Structure
+
+- Use underscores to separate words in tool names
+- Use clear, descriptive names that indicate the tool's purpose
+- Follow the pattern: `[prefix]_[action]_[optional_qualifier]`
+- Examples:
+  - `sg_find` - Find entities using ShotGrid API
+  - `note_create` - Create a note
+  - `playlist_add_versions` - Add versions to a playlist
+  - `thumbnail_download` - Download a thumbnail
+
+## Creating New Tools
+
+When creating new tools for the ShotGrid MCP Server, follow these guidelines:
+
+### 1. Choose the Appropriate Module
+
+Place your tool in the appropriate module based on its functionality:
+
+- `api_tools.py` - Direct ShotGrid API wrappers
+- `note_tools.py` - Note-related tools
+- `playlist_tools.py` - Playlist-related tools
+- `thumbnail_tools.py` - Thumbnail-related tools
+- `search_tools.py` - Search-related tools
+- `vendor_tools.py` - Vendor-related tools
+- Create a new module if your tool doesn't fit into existing categories
+
+### 2. Define the Tool Function
+
+```python
+@server.tool("prefix_action_qualifier")
+def tool_function_name(param1: Type1, param2: Type2) -> ReturnType:
+    """Tool description.
+
+    Args:
+        param1: Description of param1.
+        param2: Description of param2.
+
+    Returns:
+        Description of return value.
+
+    Raises:
+        ToolError: Description of when errors are raised.
+    """
+    try:
+        # Tool implementation
+        return result
+    except Exception as err:
+        handle_error(err, operation="tool_function_name")
+        raise  # This is needed to satisfy the type checker
+```
+
+### 3. Register the Tool
+
+Tools are registered using the `@server.tool()` decorator. Make sure to:
+
+- Use a name that follows the naming convention
+- Provide proper type hints for parameters and return values
+- Include comprehensive docstrings
+- Implement proper error handling
+
+### 4. Add Tests
+
+Create tests for your tool in the appropriate test module:
+
+- Test normal operation
+- Test error conditions
+- Test edge cases
+
+## Examples
+
+### Basic Tool Example
+
+```python
+@server.tool("entity_create")
+def create_entity(
+    entity_type: EntityType,
+    data: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Create a new entity.
+
+    Args:
+        entity_type: Type of entity to create.
+        data: Entity data.
+
+    Returns:
+        Dict[str, Any]: Created entity data.
+
+    Raises:
+        ToolError: If entity creation fails.
+    """
+    try:
+        result = sg.create(entity_type, data)
+        return result
+    except Exception as err:
+        handle_error(err, operation="create_entity")
+        raise
+```
+
+### Advanced Tool Example
+
+```python
+@server.tool("search_entities_with_related")
+async def search_entities_with_related(
+    entity_type: EntityType,
+    filters: List[Dict[str, Any]],
+    fields: List[str],
+    related_fields: Dict[str, List[str]],
+    order: Optional[List[Dict[str, str]]] = None,
+    limit: Optional[int] = None,
+) -> List[Dict[str, Any]]:
+    """Search for entities with related fields.
+
+    Args:
+        entity_type: Type of entity to search.
+        filters: Search filters.
+        fields: Fields to return.
+        related_fields: Related fields to return, keyed by field name.
+        order: Optional order specification.
+        limit: Optional result limit.
+
+    Returns:
+        List[Dict[str, Any]]: List of matching entities with related fields.
+
+    Raises:
+        ToolError: If search fails.
+    """
+    try:
+        # Implementation details...
+        return results
+    except Exception as err:
+        handle_error(err, operation="search_entities_with_related")
+        raise
+```
+
+## Conclusion
+
+Following these naming conventions and guidelines ensures that tools in the ShotGrid MCP Server are consistent, clear, and easy to use. It also helps maintain compatibility with the MCP specification and provides a better experience for users of the server.

--- a/src/shotgrid_mcp_server/tools/create_tools.py
+++ b/src/shotgrid_mcp_server/tools/create_tools.py
@@ -21,7 +21,7 @@ def register_create_tools(server: FastMCPType, sg: Shotgun) -> None:
         sg: ShotGrid connection.
     """
 
-    @server.tool("create_entity")
+    @server.tool("entity_create")
     def create_entity(entity_type: EntityType, data: Dict[str, Any]) -> EntityDict:
         """Create an entity in ShotGrid.
 
@@ -47,7 +47,7 @@ def register_create_tools(server: FastMCPType, sg: Shotgun) -> None:
             handle_error(err, operation="create_entity")
             raise  # This is needed to satisfy the type checker
 
-    @server.tool("batch_create_entities")
+    @server.tool("batch_entity_create")
     def batch_create_entities(entity_type: EntityType, data_list: List[Dict[str, Any]]) -> List[EntityDict]:
         """Create multiple entities in ShotGrid.
 

--- a/src/shotgrid_mcp_server/tools/delete_tools.py
+++ b/src/shotgrid_mcp_server/tools/delete_tools.py
@@ -21,7 +21,7 @@ def register_delete_tools(server: FastMCPType, sg: Shotgun) -> None:
         sg: ShotGrid connection.
     """
 
-    @server.tool("delete_entity")
+    @server.tool("entity_delete")
     def delete_entity(entity_type: EntityType, entity_id: int) -> None:
         """Delete an entity in ShotGrid.
 

--- a/src/shotgrid_mcp_server/tools/note_tools.py
+++ b/src/shotgrid_mcp_server/tools/note_tools.py
@@ -25,7 +25,7 @@ def register_note_tools(server: FastMCP, sg: Shotgun) -> None:
     """
 
     # Register note tools
-    @server.tool("shotgrid.note.create")
+    @server.tool("shotgrid_note_create")
     async def create_note_tool(request: NoteCreateRequest) -> NoteCreateResponse:
         """Create a new note in ShotGrid.
 
@@ -38,7 +38,7 @@ def register_note_tools(server: FastMCP, sg: Shotgun) -> None:
         context = ShotGridConnectionContext(sg)
         return create_note(request, context)
 
-    @server.tool("shotgrid.note.read")
+    @server.tool("shotgrid_note_read")
     async def read_note_tool(note_id: int) -> NoteReadResponse:
         """Read a note from ShotGrid.
 
@@ -51,7 +51,7 @@ def register_note_tools(server: FastMCP, sg: Shotgun) -> None:
         context = ShotGridConnectionContext(sg)
         return read_note(note_id, context)
 
-    @server.tool("shotgrid.note.update")
+    @server.tool("shotgrid_note_update")
     async def update_note_tool(request: NoteUpdateRequest) -> NoteUpdateResponse:
         """Update a note in ShotGrid.
 

--- a/src/shotgrid_mcp_server/tools/note_tools.py
+++ b/src/shotgrid_mcp_server/tools/note_tools.py
@@ -25,7 +25,7 @@ def register_note_tools(server: FastMCP, sg: Shotgun) -> None:
     """
 
     # Register note tools
-    @server.tool("shotgrid_note_create")
+    @server.tool("note_create")
     async def create_note_tool(request: NoteCreateRequest) -> NoteCreateResponse:
         """Create a new note in ShotGrid.
 
@@ -38,7 +38,7 @@ def register_note_tools(server: FastMCP, sg: Shotgun) -> None:
         context = ShotGridConnectionContext(sg)
         return create_note(request, context)
 
-    @server.tool("shotgrid_note_read")
+    @server.tool("note_read")
     async def read_note_tool(note_id: int) -> NoteReadResponse:
         """Read a note from ShotGrid.
 
@@ -51,7 +51,7 @@ def register_note_tools(server: FastMCP, sg: Shotgun) -> None:
         context = ShotGridConnectionContext(sg)
         return read_note(note_id, context)
 
-    @server.tool("shotgrid_note_update")
+    @server.tool("note_update")
     async def update_note_tool(request: NoteUpdateRequest) -> NoteUpdateResponse:
         """Update a note in ShotGrid.
 

--- a/src/shotgrid_mcp_server/tools/playlist_tools.py
+++ b/src/shotgrid_mcp_server/tools/playlist_tools.py
@@ -133,7 +133,7 @@ def register_playlist_tools(server: FastMCPType, sg: Shotgun) -> None:  # noqa: 
         sg: ShotGrid connection.
     """
 
-    @server.tool("find_playlists")
+    @server.tool("playlist_find")
     def find_playlists(
         filters: Optional[List[Dict[str, Any]]] = None,
         fields: Optional[List[str]] = None,
@@ -180,7 +180,7 @@ def register_playlist_tools(server: FastMCPType, sg: Shotgun) -> None:  # noqa: 
             handle_error(err, operation="find_playlists")
             raise  # This is needed to satisfy the type checker
 
-    @server.tool("find_project_playlists")
+    @server.tool("playlist_find_by_project")
     def find_project_playlists(
         project_id: int,
         fields: Optional[List[str]] = None,
@@ -226,7 +226,7 @@ def register_playlist_tools(server: FastMCPType, sg: Shotgun) -> None:  # noqa: 
             handle_error(err, operation="find_project_playlists")
             raise  # This is needed to satisfy the type checker
 
-    @server.tool("find_recent_playlists")
+    @server.tool("playlist_find_recent")
     def find_recent_playlists(
         days: int = 7,
         project_id: Optional[int] = None,
@@ -276,7 +276,7 @@ def register_playlist_tools(server: FastMCPType, sg: Shotgun) -> None:  # noqa: 
             handle_error(err, operation="find_recent_playlists")
             raise  # This is needed to satisfy the type checker
 
-    @server.tool("create_playlist")
+    @server.tool("playlist_create")
     def create_playlist(
         code: str,
         project_id: int,
@@ -337,7 +337,7 @@ def register_playlist_tools(server: FastMCPType, sg: Shotgun) -> None:  # noqa: 
             handle_error(err, operation="create_playlist")
             raise  # This is needed to satisfy the type checker
 
-    @server.tool("update_playlist")
+    @server.tool("playlist_update")
     def update_playlist(
         playlist_id: int,
         code: Optional[str] = None,
@@ -382,7 +382,7 @@ def register_playlist_tools(server: FastMCPType, sg: Shotgun) -> None:  # noqa: 
             handle_error(err, operation="update_playlist")
             raise  # This is needed to satisfy the type checker
 
-    @server.tool("add_versions_to_playlist")
+    @server.tool("playlist_add_versions")
     def add_versions_to_playlist(
         playlist_id: int,
         version_ids: List[int],

--- a/src/shotgrid_mcp_server/tools/read_tools.py
+++ b/src/shotgrid_mcp_server/tools/read_tools.py
@@ -21,7 +21,7 @@ def register_read_tools(server: FastMCPType, sg: Shotgun) -> None:
         sg: ShotGrid connection.
     """
 
-    @server.tool("get_schema")
+    @server.tool("schema_get")
     def get_schema(entity_type: EntityType) -> Dict[str, Any]:
         """Get schema for an entity type.
 

--- a/src/shotgrid_mcp_server/tools/search_tools.py
+++ b/src/shotgrid_mcp_server/tools/search_tools.py
@@ -234,7 +234,7 @@ def register_find_one_entity(server: FastMCPType, sg: Shotgun) -> None:
         sg: ShotGrid connection.
     """
 
-    @server.tool("find_one_entity")
+    @server.tool("entity_find_one")
     def find_one_entity(
         entity_type: EntityType,
         filters: List[Dict[str, Any]],  # Use Dict instead of Filter for FastMCP compatibility
@@ -423,7 +423,7 @@ def register_helper_functions(server: FastMCPType, sg: Shotgun) -> None:
         sg: ShotGrid connection.
     """
 
-    @server.tool("find_recently_active_projects")
+    @server.tool("project_find_active")
     def find_recently_active_projects(days: int = 90) -> List[Dict[str, str]]:
         """Find projects that have been active in the last N days.
 
@@ -435,7 +435,7 @@ def register_helper_functions(server: FastMCPType, sg: Shotgun) -> None:
         """
         return _find_recently_active_projects(sg, days)
 
-    @server.tool("find_active_users")
+    @server.tool("user_find_active")
     def find_active_users(days: int = 30) -> List[Dict[str, str]]:
         """Find users who have been active in the last N days.
 
@@ -447,7 +447,7 @@ def register_helper_functions(server: FastMCPType, sg: Shotgun) -> None:
         """
         return _find_active_users(sg, days)
 
-    @server.tool("find_entities_by_date_range")
+    @server.tool("entity_find_by_date")
     def find_entities_by_date_range(
         entity_type: EntityType,
         date_field: str,

--- a/src/shotgrid_mcp_server/tools/thumbnail_tools.py
+++ b/src/shotgrid_mcp_server/tools/thumbnail_tools.py
@@ -176,7 +176,7 @@ def register_thumbnail_tools(server: FastMCPType, sg: Shotgun) -> None:
     """
 
     # Register get_thumbnail_url tool
-    @server.tool("get_thumbnail_url")
+    @server.tool("thumbnail_get_url")
     def get_thumbnail_url_tool(
         entity_type: EntityType,
         entity_id: int,
@@ -194,7 +194,7 @@ def register_thumbnail_tools(server: FastMCPType, sg: Shotgun) -> None:
         )
 
     # Register download_thumbnail tool
-    @server.tool("download_thumbnail")
+    @server.tool("thumbnail_download")
     def download_thumbnail_tool(
         entity_type: EntityType,
         entity_id: int,
@@ -214,7 +214,7 @@ def register_thumbnail_tools(server: FastMCPType, sg: Shotgun) -> None:
         )
 
     # Register batch_download_thumbnails tool
-    @server.tool("batch_download_thumbnails")
+    @server.tool("batch_thumbnail_download")
     def batch_download_thumbnails_tool(operations: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         return batch_download_thumbnails(sg=sg, operations=operations)
 

--- a/src/shotgrid_mcp_server/tools/update_tools.py
+++ b/src/shotgrid_mcp_server/tools/update_tools.py
@@ -21,7 +21,7 @@ def register_update_tools(server: FastMCPType, sg: Shotgun) -> None:
         sg: ShotGrid connection.
     """
 
-    @server.tool("update_entity")
+    @server.tool("entity_update")
     def update_entity(
         entity_type: EntityType,
         entity_id: int,

--- a/tests/test_optimized_queries.py
+++ b/tests/test_optimized_queries.py
@@ -237,7 +237,7 @@ class TestOptimizedQueries:
 
         # Execute batch create
         response = await server._mcp_call_tool(
-            "batch_create_entities",
+            "batch_entity_create",
             {
                 "entity_type": "Shot",
                 "data_list": data_list,

--- a/tests/test_playlist_tools.py
+++ b/tests/test_playlist_tools.py
@@ -70,7 +70,7 @@ class TestPlaylistTools:
 
         # Call the tool
         result = await playlist_server._mcp_call_tool(
-            "find_playlists",
+            "playlist_find",
             {}
         )
 
@@ -146,7 +146,7 @@ class TestPlaylistTools:
 
         # Call the tool
         result = await playlist_server._mcp_call_tool(
-            "find_project_playlists",
+            "playlist_find_by_project",
             {"project_id": project1["id"]}
         )
 
@@ -219,7 +219,7 @@ class TestPlaylistTools:
 
         # Call the tool
         result = await playlist_server._mcp_call_tool(
-            "find_recent_playlists",
+            "playlist_find_recent",
             {"project_id": project["id"], "days": 1}
         )
 
@@ -261,7 +261,7 @@ class TestPlaylistTools:
 
         # Call the tool
         result = await playlist_server._mcp_call_tool(
-            "create_playlist",
+            "playlist_create",
             {
                 "code": "New Playlist",
                 "project_id": project["id"],
@@ -311,7 +311,7 @@ class TestPlaylistTools:
 
         # Call the tool
         result = await playlist_server._mcp_call_tool(
-            "update_playlist",
+            "playlist_update",
             {
                 "playlist_id": playlist["id"],
                 "code": "Updated Playlist",
@@ -370,7 +370,7 @@ class TestPlaylistTools:
 
         # Call the tool
         result = await playlist_server._mcp_call_tool(
-            "add_versions_to_playlist",
+            "playlist_add_versions",
             {
                 "playlist_id": playlist["id"],
                 "version_ids": [version2["id"]]

--- a/tests/test_search_tools.py
+++ b/tests/test_search_tools.py
@@ -285,7 +285,7 @@ class TestSearchTools:
 
         # Call the tool
         result = await search_server._mcp_call_tool(
-            "find_one_entity",
+            "entity_find_one",
             {
                 "entity_type": "Shot",
                 "filters": filters,
@@ -315,7 +315,7 @@ class TestSearchTools:
 
         # Call the tool
         result = await search_server._mcp_call_tool(
-            "find_one_entity",
+            "entity_find_one",
             {
                 "entity_type": "Shot",
                 "filters": filters,
@@ -357,7 +357,7 @@ class TestSearchTools:
 
         # Call the tool with default days (90)
         result = await search_server._mcp_call_tool(
-            "find_recently_active_projects",
+            "project_find_active",
             {}
         )
 
@@ -404,7 +404,7 @@ class TestSearchTools:
 
         # Call the tool with default days (30)
         result = await search_server._mcp_call_tool(
-            "find_active_users",
+            "user_find_active",
             {}
         )
 
@@ -455,7 +455,7 @@ class TestSearchTools:
 
         # Call the tool with date range
         result = await search_server._mcp_call_tool(
-            "find_entities_by_date_range",
+            "entity_find_by_date",
             {
                 "entity_type": "Shot",
                 "date_field": "created_at",


### PR DESCRIPTION
## Description

This PR standardizes the tool naming convention across the ShotGrid MCP Server codebase to improve consistency and clarity.

## Changes

- Designed a unified tool naming convention using prefixes to categorize tools
- Updated existing tool names to follow the new convention
- Created documentation explaining the tool naming convention and how to create new tools
- Ensured all tool names comply with MCP specification (`^[a-zA-Z0-9_-]{1,64}$`)

## Prefixes

Tools now use the following prefixes:

- `sg_` - Direct ShotGrid API wrappers
- `entity_` - Entity operations
- `note_` - Note-related operations
- `playlist_` - Playlist-related operations
- `thumbnail_` - Thumbnail-related operations
- `vendor_` - Vendor-related operations
- `search_` - Search operations
- `batch_` - Batch operations
- `project_` - Project-related operations
- `user_` - User-related operations
- `schema_` - Schema-related operations

## Documentation

Added a new documentation page at `docs/guides/tool-naming-convention.mdx` that explains the naming convention and provides guidelines for creating new tools.

Signed-off-by: loonghao <hal.long@outlook.com>