### PR TITLE
docs: Fix the doc in tool section by escaping `|`

### DIFF
--- a/docs/servers/tools.mdx
+++ b/docs/servers/tools.mdx
@@ -114,8 +114,8 @@ def find_tasks(
 |-----------------|---------|-------------|
 | Basic types | `int`, `float`, `str`, `bool` | Simple scalar values |
 | Container types | `List[str]`, `Dict[str, int]` | Collections of items |
-| Optional types | `Optional[float]`, `float | None` | Parameters that may be null/omitted |
-| Union types | `str | int`, `Union[str, int]` | Parameters accepting multiple types |
+| Optional types | `Optional[float]`, `float \| None` | Parameters that may be null/omitted |
+| Union types | `str \| int`, `Union[str, int]` | Parameters accepting multiple types |
 | Literal types | `Literal["ip", "cmpt"]` | Parameters with specific allowed values |
 | Pydantic models | `AssetData` | Complex structured data |
 


### PR DESCRIPTION
before:
<img width="714" alt="Screenshot 2025-06-09 at 11 50 34 AM" src="https://github.com/user-attachments/assets/851ee1cc-6e2d-4a2e-8e00-9c0523eea88e" />

after:
<img width="698" alt="Screenshot 2025-06-09 at 11 50 56 AM" src="https://github.com/user-attachments/assets/4bebadd9-e2f0-4e23-927a-08e63b14982b" />
