### PR TITLE
Fix PyPI wheel ZIP validation for shotgrid-mcp-server

### DIFF
--- a/nox_actions/release.py
+++ b/nox_actions/release.py
@@ -40,11 +40,10 @@ def build_wheel(session: nox.Session) -> None:
     This avoids any interference from the current environment that could
     produce non-standard ZIP archives rejected by PyPI.
     """
-    # Install uv if not already installed
-    session.run("python", "-m", "pip", "install", "uv", silent=True)
+    # Install the build helper into the nox environment. `python -m build`
+    # will then create an isolated PEP 517 environment based on
+    # ``[build-system]`` in ``pyproject.toml``.
+    session.install("build")
 
-    # Install build dependencies using uv inside the session environment
-    session.run("uv", "pip", "install", "build", external=True)
-
-    # Build wheel using an isolated PEP 517 environment
+    # Build wheel using an isolated PEP 517 environment.
     session.run("python", "-m", "build", "--wheel")

--- a/noxfile.py
+++ b/noxfile.py
@@ -71,17 +71,8 @@ def lint_fix(session: nox.Session) -> None:
 @nox.session(name="build-wheel")
 def build_wheel(session: nox.Session) -> None:
     """Build Python wheel package."""
-    # Install uv if not already installed
-    session.run("python", "-m", "pip", "install", "uv", silent=True)
-
-    # Use uv to install dependencies
-    session.run("uv", "pip", "install", "-e", ".[build]", external=True)
-
-    # Install build and hatchling
-    session.run("python", "-m", "pip", "install", "uv", silent=True)
-    session.run("uv", "pip", "install", "build", "hatchling", external=True)
-
-    # Build wheel
+    # Delegate to the shared release helper, which uses ``python -m build``
+    # with an isolated PEP 517 environment.
     release.build_wheel(session)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,10 +86,6 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["src/shotgrid_mcp_server"]
 
-[tool.hatch.build.force-include]
-"tests/data/schema.bin" = "src/shotgrid_mcp_server/data/schema.bin"
-"tests/data/entity_schema.bin" = "src/shotgrid_mcp_server/data/entity_schema.bin"
-
 [tool.hatch.metadata]
 allow-direct-references = true
 


### PR DESCRIPTION
This PR fixes the PyPI publish failure caused by an invalid wheel ZIP archive ("ZIP archive not accepted: Mis-matched data size").

Key changes:
- Build the wheel via a standard PEP 517 isolated environment using `python -m build --wheel` inside a nox session.
- Remove `tool.hatch.build.force-include` entries that were copying `tests/data/schema.bin` and `tests/data/entity_schema.bin` into `src/shotgrid_mcp_server/data`, which produced duplicate ZIP records for the same paths.

Validation:
- `uvx nox -s tests` (all tests passing, some expected skips).
- `uvx nox -s build-wheel` to build `shotgrid_mcp_server-0.10.0-py3-none-any.whl`.
- `python -m zipfile -t dist/shotgrid_mcp_server-0.10.0-py3-none-any.whl` to verify ZIP structure (reports `Done testing` with no warnings or errors).

With these changes, the wheel should satisfy PyPI's archive format requirements as documented in https://docs.pypi.org/archives/ and should no longer trigger ZIP validation failures during publish.