### PR TITLE
fix: replace deprecated class-based Config with ConfigDict for Pydantic V2 compatibility

### DIFF
--- a/src/shotgrid_mcp_server/api_models.py
+++ b/src/shotgrid_mcp_server/api_models.py
@@ -10,7 +10,7 @@ https://developers.shotgridsoftware.com/python-api/reference.html
 import re
 from typing import Any, Dict, List, Literal, Optional
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from shotgrid_mcp_server.custom_types import EntityType
 from shotgrid_mcp_server.models import TimeFilter
@@ -63,10 +63,7 @@ class BaseAPIRequest(BaseModel):
     validation and configuration across all ShotGrid API operations.
     """
 
-    class Config:
-        """Pydantic configuration."""
-
-        extra = "forbid"  # Prevent extra fields to catch typos early
+    model_config = ConfigDict(extra="forbid")  # Prevent extra fields to catch typos early
 
 
 class FindRequest(BaseAPIRequest):

--- a/src/shotgrid_mcp_server/models.py
+++ b/src/shotgrid_mcp_server/models.py
@@ -11,7 +11,7 @@ from datetime import date, datetime, timedelta
 from enum import Enum
 from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 # Import core models from shotgrid-query
 from shotgrid_query import (
@@ -85,12 +85,11 @@ class ShotGridDataType(str, Enum):
 class EntityRef(BaseModel):
     """ShotGrid entity reference (MCP-specific)."""
 
+    model_config = ConfigDict(extra="allow")  # Allow extra fields
+
     type: str
     id: int
     name: Optional[str] = None
-
-    class Config:
-        extra = "allow"  # Allow extra fields
 
 
 # Note: Filter, FilterOperator, TimeUnit, TimeFilter are now imported from shotgrid-query
@@ -155,6 +154,8 @@ class DateRangeFilter(BaseModel):
 class ProjectDict(BaseModel):
     """ShotGrid project dictionary."""
 
+    model_config = ConfigDict(extra="allow")  # Allow extra fields
+
     id: int
     type: str
     name: str
@@ -162,12 +163,11 @@ class ProjectDict(BaseModel):
     updated_at: Optional[str] = None
     updated_by: Optional[EntityRef] = None
 
-    class Config:
-        extra = "allow"  # Allow extra fields
-
 
 class UserDict(BaseModel):
     """ShotGrid user dictionary."""
+
+    model_config = ConfigDict(extra="allow")  # Allow extra fields
 
     id: int
     type: str
@@ -177,12 +177,11 @@ class UserDict(BaseModel):
     last_login: Optional[str] = None
     sg_status_list: Optional[str] = None
 
-    class Config:
-        extra = "allow"  # Allow extra fields
-
 
 class EntityDict(BaseModel):
     """ShotGrid entity dictionary."""
+
+    model_config = ConfigDict(extra="allow")  # Allow extra fields
 
     id: int
     type: str
@@ -191,9 +190,6 @@ class EntityDict(BaseModel):
     created_at: Optional[str] = None
     updated_at: Optional[str] = None
     sg_status_list: Optional[str] = None
-
-    class Config:
-        extra = "allow"  # Allow extra fields
 
 
 class ProjectsResponse(BaseModel):


### PR DESCRIPTION
## Summary

Fix Pydantic V2 deprecation warnings by replacing the deprecated `class Config:` pattern with `model_config = ConfigDict(...)`.

## Changes

- **models.py**: Updated `EntityRef`, `ProjectDict`, `UserDict`, `EntityDict` to use `model_config = ConfigDict(extra="allow")`
- **api_models.py**: Updated `BaseAPIRequest` to use `model_config = ConfigDict(extra="forbid")`

## Fixed Warnings

```
PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead.
Deprecated in Pydantic V2.0 to be removed in V3.0.
```

## References

- [Pydantic V2 Migration Guide](https://errors.pydantic.dev/2.12/migration/)