### PR TITLE
fix(cloud): use HTTP ASGI app for FastMCP Cloud multi-site support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,43 +16,7 @@ A high-performance ShotGrid Model Context Protocol (MCP) server implementation b
 
 </div>
 
-## 🏗️ Architecture
-
-```mermaid
-flowchart TB
-    subgraph Clients["🤖 MCP Clients"]
-        direction LR
-        CLAUDE["Claude Desktop"]
-        CURSOR["Cursor"]
-        VSCODE["VS Code"]
-        AI["Other AI"]
-    end
-
-    subgraph MCP["⚡ ShotGrid MCP Server"]
-        direction LR
-        TOOLS["40+ Tools"]
-        POOL["Connection Pool"]
-        SCHEMA["Schema Cache"]
-    end
-
-    subgraph ShotGrid["🎬 ShotGrid API"]
-        direction LR
-        P["Projects"]
-        S["Shots"]
-        A["Assets"]
-        T["Tasks"]
-        N["Notes"]
-    end
-
-    Clients -->|"MCP Protocol<br/>stdio / http"| MCP
-    MCP -->|"REST API"| ShotGrid
-
-    style Clients fill:#2ecc71,stroke:#27ae60,color:#fff
-    style MCP fill:#3498db,stroke:#2980b9,color:#fff
-    style ShotGrid fill:#e74c3c,stroke:#c0392b,color:#fff
-```
-
-## 🎬 Demo
+##  Demo
 
 Here's a simple example of querying entities using the ShotGrid MCP server:
 
@@ -560,3 +524,39 @@ In the configuration examples above, replace the following values with your Shot
 ### 🛡️ Tool Permissions
 
 The `alwaysAllow` section lists the tools that can be executed without requiring user confirmation. These tools are carefully selected for safe operations. You can customize this list based on your security requirements.
+
+## 🏗️ Architecture
+
+```mermaid
+flowchart TB
+    subgraph Clients["🤖 MCP Clients"]
+        direction LR
+        CLAUDE["Claude Desktop"]
+        CURSOR["Cursor"]
+        VSCODE["VS Code"]
+        AI["Other AI"]
+    end
+
+    subgraph MCP["⚡ ShotGrid MCP Server"]
+        direction LR
+        TOOLS["40+ Tools"]
+        POOL["Connection Pool"]
+        SCHEMA["Schema Cache"]
+    end
+
+    subgraph ShotGrid["🎬 ShotGrid API"]
+        direction LR
+        P["Projects"]
+        S["Shots"]
+        A["Assets"]
+        T["Tasks"]
+        N["Notes"]
+    end
+
+    Clients -->|"MCP Protocol<br/>stdio / http"| MCP
+    MCP -->|"REST API"| ShotGrid
+
+    style Clients fill:#2ecc71,stroke:#27ae60,color:#fff
+    style MCP fill:#3498db,stroke:#2980b9,color:#fff
+    style ShotGrid fill:#e74c3c,stroke:#c0392b,color:#fff
+```

--- a/README_zh.md
+++ b/README_zh.md
@@ -15,41 +15,11 @@
 
 </div>
 
-## 🏗️ 架构
+## 🎬 演示
 
-```mermaid
-flowchart TB
-    subgraph Clients["🤖 MCP 客户端"]
-        direction LR
-        CLAUDE["Claude Desktop"]
-        CURSOR["Cursor"]
-        VSCODE["VS Code"]
-        AI["其他 AI"]
-    end
+这是一个使用 ShotGrid MCP 服务器查询实体的简单示例：
 
-    subgraph MCP["⚡ ShotGrid MCP Server"]
-        direction LR
-        TOOLS["40+ 工具"]
-        POOL["连接池"]
-        SCHEMA["Schema 缓存"]
-    end
-
-    subgraph ShotGrid["🎬 ShotGrid API"]
-        direction LR
-        P["项目"]
-        S["镜头"]
-        A["资产"]
-        T["任务"]
-        N["备注"]
-    end
-
-    Clients -->|"MCP 协议<br/>stdio / http"| MCP
-    MCP -->|"REST API"| ShotGrid
-
-    style Clients fill:#2ecc71,stroke:#27ae60,color:#fff
-    style MCP fill:#3498db,stroke:#2980b9,color:#fff
-    style ShotGrid fill:#e74c3c,stroke:#c0392b,color:#fff
-```
+![ShotGrid MCP Server Demo](images/sg-mcp.gif)
 
 ## ✨ 特性
 
@@ -559,3 +529,39 @@ MIT许可证 - 查看[LICENSE](LICENSE)文件了解详情。
 ### 🛡️ 工具权限
 
 `alwaysAllow`部分列出了可以无需用户确认即可执行的工具。这些工具经过精心选择，确保操作安全。您可以根据安全需求自定义此列表。
+
+## 🏗️ 架构
+
+```mermaid
+flowchart TB
+    subgraph Clients["🤖 MCP 客户端"]
+        direction LR
+        CLAUDE["Claude Desktop"]
+        CURSOR["Cursor"]
+        VSCODE["VS Code"]
+        AI["其他 AI"]
+    end
+
+    subgraph MCP["⚡ ShotGrid MCP Server"]
+        direction LR
+        TOOLS["40+ 工具"]
+        POOL["连接池"]
+        SCHEMA["Schema 缓存"]
+    end
+
+    subgraph ShotGrid["🎬 ShotGrid API"]
+        direction LR
+        P["项目"]
+        S["镜头"]
+        A["资产"]
+        T["任务"]
+        N["备注"]
+    end
+
+    Clients -->|"MCP 协议<br/>stdio / http"| MCP
+    MCP -->|"REST API"| ShotGrid
+
+    style Clients fill:#2ecc71,stroke:#27ae60,color:#fff
+    style MCP fill:#3498db,stroke:#2980b9,color:#fff
+    style ShotGrid fill:#e74c3c,stroke:#c0392b,color:#fff
+```

--- a/fastmcp_entry.py
+++ b/fastmcp_entry.py
@@ -8,7 +8,12 @@ FastMCP Cloud Configuration:
     Entrypoint: fastmcp_entry.py
     Requirements File: requirements.txt
 
-Environment Variables:
+HTTP Headers for Multi-Site Support:
+    X-ShotGrid-URL:         ShotGrid server URL for this request
+    X-ShotGrid-Script-Name: Script name for this request
+    X-ShotGrid-Script-Key:  API key for this request
+
+Environment Variables (fallback):
     SHOTGRID_URL:         Your ShotGrid server URL
     SHOTGRID_SCRIPT_NAME: Your ShotGrid script name
     SHOTGRID_SCRIPT_KEY:  Your ShotGrid script key
@@ -27,11 +32,14 @@ if _src_dir not in sys.path:
 # Now we can import the server module
 from shotgrid_mcp_server.server import create_server
 
-# Module-level MCP instance for FastMCP Cloud
-# FastMCP Cloud looks for 'mcp', 'server', or 'app' in the entrypoint file
+# Create MCP server with lazy connection for HTTP mode
+# Credentials will be provided via HTTP headers or environment variables
 mcp = create_server(lazy_connection=True, preload_schema=False)
 
-# Alternative names that FastMCP Cloud might look for
+# Export the HTTP ASGI app for deployment
+# This enables multi-site support through HTTP headers
+app = mcp.http_app(path="/mcp")
+
+# Alternative name
 server = mcp
-app = mcp
 


### PR DESCRIPTION
## Summary

Fix FastMCP Cloud deployment to use HTTP mode, enabling multi-site support through request headers.

## Changes

- Changed `fastmcp_entry.py` to export `http_app()` instead of raw FastMCP instance
- This enables credentials to be passed via HTTP headers:
  - `X-ShotGrid-URL`
  - `X-ShotGrid-Script-Name`
  - `X-ShotGrid-Script-Key`

## Testing

Deploy to FastMCP Cloud and verify multi-site support works via HTTP headers.